### PR TITLE
add `vscode` formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,58 @@ A collection of custom TSLint formatters. With colors.
 Included Formatters
 -------------------
 
-- `grouped`
+### `grouped`
+
+Prints a block for each file with the file name as headline.
 
 ![custom tslint formatter grouped](docs/screenshots/grouped.png)
+
+### `vscode`
+
+This is a technical formatter that can be used as input for a task in Visual Studio Code to lint all files in a project.
+
+![vscode lint task](https://cloud.githubusercontent.com/assets/761683/16345792/16a2595a-3a44-11e6-9e54-023f7d7e5611.gif)
+
+#### Usage
+
+First add a new npm task to your `package.json`:
+
+```json
+{
+  "lint:vscode": "tslint -s node_modules/custom-tslint-formatters/formatters -t vscode 'src/**/*.+(ts|tsx)'"
+}
+```
+
+Then add a new task to `.vscode/tasks.json`:
+
+```json
+{
+  "version": "0.1.0",
+  "command": "npm",
+  "isShellCommand": true,
+  "showOutput": "always",
+  "suppressTaskName": true,
+  "tasks": [
+    {
+      "taskName": "lint",
+      "args": ["run", "lint:vscode"],
+      "problemMatcher": {
+        "owner": "tslint",
+        "fileLocation": ["relative", "${workspaceRoot}"],
+        "severity": "warning",
+        "pattern": {
+          "regexp": "^\\[tslint\\] (.*):(\\d+):(\\d+):\\s+(.*)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4
+        }
+      },
+      "showOutput": "never"
+    }
+  ]
+}
+```
 
 Installation
 ------------

--- a/formatters/vscodeFormatter.ts
+++ b/formatters/vscodeFormatter.ts
@@ -1,0 +1,16 @@
+import * as ts from 'typescript';
+import * as Lint from 'tslint/lib/lint';
+
+export class Formatter extends Lint.Formatters.AbstractFormatter {
+  private formatFailure(failure: Lint.RuleFailure): string {
+    const fileName = failure.getFileName();
+    const {line, character} = failure.getStartPosition().getLineAndCharacter();
+    const message = failure.getFailure();
+    const ruleName = failure.getRuleName();
+    return `[tslint] ${fileName}:${line + 1}:${character + 1}: ${message} (${ruleName})`;
+  }
+
+  public format(failures: Lint.RuleFailure[]): string {
+    return failures.map(this.formatFailure).join('\n') + '\n';
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "tsc",
     "dev": "npm run build -- -w",
     "lint:grouped": "tslint -s formatters -t grouped test/*.ts",
+    "lint:vscode": "tslint -s formatters -t vscode test/*.ts",
     "prepublish": "npm run build"
   },
   "repository": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
   },
   "files": [
     "formatters/groupedFormatter.ts",
+    "formatters/vscodeFormatter.ts",
     "typings/colors.d.ts"
   ]
 }


### PR DESCRIPTION
A technical formatter that can be used for a task in Visual Studio code to lint a project.
