### PR TITLE
upgraded to tslint 4.0

### DIFF
--- a/formatters/groupedFormatter.ts
+++ b/formatters/groupedFormatter.ts
@@ -1,5 +1,4 @@
-import * as ts from 'typescript';
-import * as Lint from 'tslint/lib/lint';
+import * as Lint from 'tslint';
 import 'colors';
 
 interface IGroupedFailures {

--- a/formatters/vscodeFormatter.ts
+++ b/formatters/vscodeFormatter.ts
@@ -1,6 +1,5 @@
 import * as path from 'path';
-import * as ts from 'typescript';
-import * as Lint from 'tslint/lib/lint';
+import * as Lint from 'tslint';
 
 export class Formatter extends Lint.Formatters.AbstractFormatter {
   private formatFailure(failure: Lint.RuleFailure): string {

--- a/package.json
+++ b/package.json
@@ -26,11 +26,11 @@
   },
   "homepage": "https://github.com/KingHenne/custom-tslint-formatters#readme",
   "peerDependencies": {
-    "tslint": "^3.0.0"
+    "tslint": "^4.0.0"
   },
   "devDependencies": {
-    "tslint": "^3.11.0",
-    "typescript": "^1.8.10"
+    "tslint": "^4.0.1",
+    "typescript": "^2.0.10"
   },
   "dependencies": {
     "colors": "^1.1.2"


### PR DESCRIPTION
Since there are no tests to make sure that everything works here is a manual test:

```
jmlopez in ~/Workspace/custom-tslint-formatters on tslint-4.0*$ tsc
jmlopez in ~/Workspace/custom-tslint-formatters on tslint-4.0*$ tslint -s formatters -t grouped test/*.ts
test/test1.ts
  1:1 Forbidden 'var' keyword, use 'let' or 'const' instead no-var-keyword
  1:12 Missing semicolon semicolon


test/test2.ts
  1:9 " should be ' quotemark
  1:8 missing whitespace whitespace
  1:9 missing whitespace whitespace

jmlopez in ~/Workspace/custom-tslint-formatters on tslint-4.0*$ tslint -s formatters -t vscode test/*.ts
[tslint] test/test1.ts:1:1: Forbidden 'var' keyword, use 'let' or 'const' instead (no-var-keyword)
[tslint] test/test1.ts:1:12: Missing semicolon (semicolon)
[tslint] test/test2.ts:1:9: " should be ' (quotemark)
[tslint] test/test2.ts:1:8: missing whitespace (whitespace)
[tslint] test/test2.ts:1:9: missing whitespace (whitespace)
```